### PR TITLE
fix: applicable questions not showing on ODK Collect

### DIFF
--- a/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/__init__.py
+++ b/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/__init__.py
@@ -41,8 +41,10 @@ from .functions import (
     string,
 )
 from .literals import (
+    FALSE,
     ONE,
     THREE,
+    TRUE,
     TWO,
     ZERO,
     Boolean,
@@ -57,8 +59,10 @@ from .literals import (
 )
 
 __all__ = [
+    "FALSE",
     "ONE",
     "THREE",
+    "TRUE",
     "TWO",
     "ZERO",
     "Abs",

--- a/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/literals.py
+++ b/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/literals.py
@@ -32,7 +32,7 @@ class LiteralValue(Expr, Generic[_T]):
 @frozen(eq=False)
 class Boolean(BoolExpr, LiteralValue[bool]):
     def __eval__(self) -> XPathExpr:
-        return XPathExpr(f'{"yes" if self.value else "no"}')
+        return XPathExpr(f'{"true()" if self.value else "false()"}')
 
 
 @frozen(eq=False)


### PR DESCRIPTION
Due to how [Collect](https://docs.getodk.org/collect-intro/)(both ODK and Kobo) is implemented, there is an issue that results in all applicable questions on forms generated by this tool not being displayed by Collect. This is because, in Collect, all values and expressions for non-relevant questions are treated as blanks. [Here](https://forum.getodk.org/t/enketo-uses-non-relevant-values-in-calculations-whereas-collect-does-not/35567) are more details regarding this issue. Specifically, see [this comment](https://forum.getodk.org/t/enketo-uses-non-relevant-values-in-calculations-whereas-collect-does-not/35567/9#). This is a Collect-only issue and does not occur in Enketo.

To understand how this issue affects this tool, you need to know the following:

1. Each _"primary"_ question has an associated _"relevance"_ question.
2. Each _"relevance"_ question accepts a yes/no answer(default "yes") that determines whether the associated _primary_ question will be show.
3. Each applicable "primary" question has its associated _relevance_ question hidden (relevant set to `false`) since we know its answer will always be yes.

Apply as a fix, a short-circuiting `if` expression that avoids reading the value of the _"relevance"_ question for applicable questions by always evaluating to `true`. This is possible because all applicable questions are known beforehand at form generation time.

Another solution might be to remove _"relevance"_ questions for applicable questions. However, this might have the downside of littering the code with dozens of "if, else" statements and complicating the scoring calculations. In the future, this approach may be considered. However, as of now, it's not clear whether this is a good idea.