### PR TITLE
chore(deps): add py3.12 support and drop py3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,18 @@ classifiers = [
 ]
 dependencies = [
     "antlr4-python3-runtime==4.13.0",
-    "attrs~=23.1.0",
-    "cattrs~=23.1.2",
+    "attrs~=23.2.0",
+    "cattrs~=23.2.3",
     "click~=8.1.7",
+    # Pin this to 3.0.10. See this issue for details:
+    # https://github.com/pyexcel/pyexcel-xlsx/issues/52
     "openpyxl==3.0.10",
     "pyexcel~=0.7.0",
     "pyexcel-io~=0.6.6",
     "pyexcel-xls~=0.7.0",
     "pyexcel-xlsx~=0.6.0",
-    "sghi-commons @ git+https://github.com/savannahghi/sghi-commons.git@develop",
+    "sghi-commons @ git+https://github.com/savannahghi/sghi-commons.git@v1.4.0",
+    "sghi-etl-commons @ git+https://github.com/savannahghi/sghi-etl-commons.git@v1.1.0-rc.2",
     "typing_extensions>=4.8.0",
 ]
 description = "Mentorship tools as XForms."
@@ -45,62 +48,65 @@ maintainers = [
 ]
 name = "mentorship-xls-forms"
 readme = "README.md"
-requires-python = ">=3.10" # Support Python 3.10+.
+requires-python = ">=3.12" # Support Python 3.12+.
 
 [project.optional-dependencies]
 dev = [
-    "pre-commit~=3.4.0",
+    "pre-commit~=3.7.1",
 ]
 
 docs = [
-    "furo==2023.8.19",
-    "jaraco.packaging~=9.4.0",
-    "rst.linker~=2.4.0",
-    "Sphinx~=7.2.5",
+    "furo==2024.5.6",
+    "jaraco.packaging~=10.1.0",
+    "rst.linker~=2.6.0",
+    "Sphinx~=7.3.7",
     "sphinx-favicon~=1.0.1",
-    "sphinx-hoverxref~=1.3.0",
+    "sphinx-hoverxref~=1.4.0",
     "sphinx-inline-tabs~=2023.4.21",
-    "sphinx-lint~=0.6.8",
-    "sphinx-notfound-page~=1.0.0",
+    "sphinx-lint~=0.9.1",
+    "sphinx-notfound-page~=1.0.2",
 ]
 
 test = [
-    "black==23.10.1",  # Pin this
-    "coverage~=6.5.0",
-    "coveralls~=3.3.1",
+    "coverage~=7.5.3",
+    "coveralls~=4.0.1",
     "factory-boy~=3.3.0",
     "packaging",
-    "pyright>=1.1.325",
-    "pytest~=7.4.1",
-    "pytest-cov~=4.1.0",
+    "pyright>=1.1.365",
+    "pytest~=8.2.1",
+    "pytest-cov~=5.0.0",
     "pytest-forked~=1.6.0",
-    "pytest-sugar~=0.9.7",
-    "pytest-xdist~=3.3.1",
-    "ruff~=0.0.292",
-    "tomli~=2.0.1",
-    "tox~=4.11.1",
-    "tox-gh-actions~=3.1.3",
+    "pytest-sugar~=1.0.0",
+    "pytest-xdist~=3.6.1",
+    "ruff~=0.4.7",
+    "tox~=4.15.0",
+    "tox-gh-actions~=3.2.0",
 ]
 
 [project.scripts]
 mentorship-xls-forms = "sghi.mentorship_xls_forms.__main__:main"
 
 [project.urls]
-changelog = "https://github.com/savannahghi/sghi-python-utils/blob/develop/docs/CHANGELOG.md"
-documentation = "https://github.com/savannahghi/sghi-python-utils/blob/develop/README.md"
-homepage = "https://github.com/savannahghi/sghi-python-utils"
-repository = "https://github.com/savannahghi/sghi-python-utils.git"
+changelog = "https://github.com/savannahghi/mentorship-xls-form/blob/develop/docs/CHANGELOG.md"
+documentation = "https://github.com/savannahghi/mentorship-xls-form/blob/develop/README.md"
+homepage = "https://github.com/savannahghi/mentorship-xls-form"
+repository = "https://github.com/savannahghi/mentorship-xls-form.git"
 
 [tool.black]
-line-length = 79
-target-version = ["py310"]
+extend-exclude = """
+# A regex preceded with ^/ will apply only to files and directories
+# in the root of the project.
+(
+  ^/docs/_*.py
+)
+"""
 
 [tool.coverage.html]
 directory = "coverage"
 
 [tool.coverage.report]
 exclude_lines = [
-    # Have to re-enable the standard pragma"
+    # Have to re-enable the standard pragma:
     "pragma: no branch",
     "pragma: nocover",
     "pragma: no cover",
@@ -110,7 +116,13 @@ exclude_lines = [
     "raise NotImplementedError",
 
     # Don't complain about abstract methods, they aren't run:
-    '@(abc\.)?abstractmethod'
+    '@(abc\.)?abstractmethod',
+
+    # Don't complain about conditional TYPE_CHECKING blocks:
+    'if (typing\.)?TYPE_CHECKING:',
+
+    # Don't complain about overloads:
+    '@(typing\.)?overload',
 ]
 show_missing = true
 
@@ -189,16 +201,29 @@ extend-exclude = [
     "node_modules",
     "venv",
 ]
-fixable = ["ALL"]
+line-length = 79
+src = ["src", "test"]
+target-version = "py312"
+
+[tool.ruff.format]
+docstring-code-format = true
+indent-style = "space"
+quote-style = "double"
+skip-magic-trailing-comma = false
+
+[tool.ruff.lint]
 ignore = [
     "ANN002",
     "ANN003",
     "ANN101",
     "ANN102",
     "ANN204",
-    "S101"
+    "COM812",
+    "D203",
+    "D213",
+    "ISC001",
+    "S101",
 ]
-line-length = 79
 select = [
     "A",   # flake8-builtins
     "ANN", # flake8-annotations
@@ -231,17 +256,15 @@ select = [
     "W",   # pycodestyle Warning
     "YTT", # flake8-2020
 ]
-src = ["src", "test"]
-target-version = "py310"
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
 docstring-quotes = "double"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["sghi"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.setuptools]
@@ -257,7 +280,7 @@ root = "."
 [tool.tox]
 legacy_tox_ini = """
     [tox]
-    env_list = {py310, py311}, coveralls, docs, package
+    env_list = py312, coveralls, docs, package
     isolated_build = true
     no_package = false
     requires =
@@ -267,22 +290,23 @@ legacy_tox_ini = """
 
     [gh-actions]
     python =
-        3.10: py310
-        3.11: py311, coveralls, docs, package
+        3.12: py312, coveralls, docs, package
 
 
     [testenv]
     commands =
-        ruff .
-        black --check src test
+        ruff check .
+        ruff format --check .
         pyright .
         coverage erase
-        pytest {posargs:.}
+        -pytest {posargs:.}
         coverage html
     deps =
         .
     description = test and lint the project
     download = true
+    extras =
+        test
     set_env =
         PYTHONPATH = {toxinidir}/src
         PYRIGHT_PYTHON_FORCE_VERSION = latest
@@ -294,6 +318,8 @@ legacy_tox_ini = """
     commands =
         coveralls --service=github
     description = submit coverage results to coverall.io
+    extras =
+        test
     pass_env =
         COVERALLS_REPO_TOKEN
         GITHUB_*
@@ -302,7 +328,7 @@ legacy_tox_ini = """
     [testenv:docs]
     changedir = docs
     commands =
-        sphinx-build -EW --keep-going -b html . {toxinidir}/docs/build/html
+        -sphinx-build -EW --keep-going -b html . {toxinidir}/docs/build/html
         sphinx-lint -i api
     description = build sphinx documentation
     extras =

--- a/src/sghi/mentorship_xls_forms/core/domain.py
+++ b/src/sghi/mentorship_xls_forms/core/domain.py
@@ -67,7 +67,7 @@ class QuestionType(StrEnum):
 # =============================================================================
 
 
-class DomainObject(metaclass=ABCMeta):
+class DomainObject(metaclass=ABCMeta):  # noqa: B024
     """Marker interface that identifies a domain object.
 
     All domain objects should implement this interface.
@@ -94,7 +94,7 @@ class Facility(DomainObject):
 class Question(DomainObject):
     """A question in a mentorship checklist."""
 
-    id: str = field()  # noqa: A003
+    id: str = field()
     label: str = field(hash=False)
     question_type: QuestionType = field()
     answer_type: AnswerType = field(repr=False)
@@ -144,7 +144,7 @@ class Question(DomainObject):
 class Section(DomainObject):
     """A section in a mentorship checklist."""
 
-    id: str = field()  # noqa: A003
+    id: str = field()
     title: str = field(hash=False)
     standard: str | None = field(
         default=None,
@@ -181,7 +181,7 @@ class Section(DomainObject):
 class MentorshipChecklist(DomainObject):
     """A mentorship checklist."""
 
-    id: str = field()  # noqa: A003
+    id: str = field()
     name: str = field(hash=False)
     sections: Mapping[str, Section] | None = field(
         default=None,

--- a/src/sghi/mentorship_xls_forms/core/loader.py
+++ b/src/sghi/mentorship_xls_forms/core/loader.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Generic, TypeVar
+from typing import override
 
-from sghi.disposable import Disposable
+from sghi.etl.core import Source
 from sghi.exceptions import SGHIError
-
-# =============================================================================
-# TYPES
-# =============================================================================
-
-_D = TypeVar("_D")
-
 
 # =============================================================================
 # EXCEPTIONS
@@ -27,7 +20,7 @@ class LoadError(SGHIError):
 # =============================================================================
 
 
-class Loader(Disposable, Generic[_D], metaclass=ABCMeta):
+class Loader[_DT](Source[_DT], metaclass=ABCMeta):
     """
     Interface representing objects that read data from a source (or generate
     the data) for further processing or internal consumption by this tool.
@@ -36,7 +29,7 @@ class Loader(Disposable, Generic[_D], metaclass=ABCMeta):
     __slots__ = ()
 
     @abstractmethod
-    def load(self) -> _D:
+    def load(self) -> _DT:
         """
         Read data from a source and return it for further processing or
         internal consumption.
@@ -47,3 +40,7 @@ class Loader(Disposable, Generic[_D], metaclass=ABCMeta):
             source.
         """
         ...
+
+    @override
+    def draw(self) -> _DT:
+        return self.load()

--- a/src/sghi/mentorship_xls_forms/core/serializer.py
+++ b/src/sghi/mentorship_xls_forms/core/serializer.py
@@ -1,30 +1,19 @@
 from abc import ABCMeta, abstractmethod
-from typing import Generic, TypeVar
-
-# =============================================================================
-# TYPES
-# =============================================================================
-
-_P = TypeVar("_P")
-_R = TypeVar("_R")
-
 
 # =============================================================================
 # INTERFACES
 # =============================================================================
 
 
-class Deserializer(Generic[_R, _P], metaclass=ABCMeta):
+class Deserializer[_RT, _PT](metaclass=ABCMeta):
     __slots__ = ()
 
     @abstractmethod
-    def deserialize(self, data: _R) -> _P:
-        ...
+    def deserialize(self, data: _RT) -> _PT: ...
 
 
-class Serializer(Generic[_P, _R], metaclass=ABCMeta):
+class Serializer[_PT, _RT](metaclass=ABCMeta):
     __slots__ = ()
 
     @abstractmethod
-    def serialize(self, item: _P) -> _R:
-        ...
+    def serialize(self, item: _PT) -> _RT: ...

--- a/src/sghi/mentorship_xls_forms/core/writer.py
+++ b/src/sghi/mentorship_xls_forms/core/writer.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Generic, TypeVar
+from typing import override
 
-from sghi.disposable import Disposable
+from sghi.etl.core import Sink
 from sghi.exceptions import SGHIError
-
-# =============================================================================
-# TYPES
-# =============================================================================
-
-_D = TypeVar("_D")
-
 
 # =============================================================================
 # EXCEPTIONS
@@ -27,7 +20,7 @@ class WriteError(SGHIError):
 # =============================================================================
 
 
-class Writer(Disposable, Generic[_D], metaclass=ABCMeta):
+class Writer[_DT](Sink[_DT], metaclass=ABCMeta):
     """
     Interface representing objects that persist processed data to a final
     destination for further consumption by other tools *down stream*.
@@ -36,7 +29,7 @@ class Writer(Disposable, Generic[_D], metaclass=ABCMeta):
     __slots__ = ()
 
     @abstractmethod
-    def write(self, data: _D) -> None:
+    def write(self, data: _DT) -> None:
         """Persist the given data to a destination.
 
         :param data: The data to persist.
@@ -47,3 +40,7 @@ class Writer(Disposable, Generic[_D], metaclass=ABCMeta):
             data.
         """
         ...
+
+    @override
+    def drain(self, processed_data: _DT) -> None:
+        return self.write(processed_data)

--- a/src/sghi/mentorship_xls_forms/lib/antlr4/__init__.py
+++ b/src/sghi/mentorship_xls_forms/lib/antlr4/__init__.py
@@ -61,8 +61,7 @@ MetaCeeScore = Literal["Gray", "Green", "Red", "Yellow"]
 
 class _HasCeeScore(Protocol):
     @abstractmethod
-    def CEE_SCORE(self) -> TerminalNode | None:
-        ...
+    def CEE_SCORE(self) -> TerminalNode | None: ...
 
 
 # =============================================================================
@@ -92,7 +91,7 @@ QT = QuestionType
 def _get_term_node_txt(terminal_node: TerminalNode | None) -> str:
     assert isinstance(terminal_node, TerminalNodeImpl)
     assert terminal_node.getText() is not None
-    return terminal_node.getText()  # type: ignore
+    return terminal_node.getText()
 
 
 def _meta_cee_score_to_xls_form(meta_cee_score: MetaCeeScore | str) -> str_:
@@ -181,8 +180,7 @@ class MetadataExpressionSyntaxError(ParseError):
 class Listener(metaclass=ABCMeta):
     @property
     @abstractmethod
-    def walk_results(self) -> ListenerWalkResults:
-        ...
+    def walk_results(self) -> ListenerWalkResults: ...
 
 
 @define
@@ -279,9 +277,7 @@ class ScoringLogicListener(SGHI_XLSFormListener, Listener):
             #   if(not(selected(${SIMS.S_01_02_CondomAvail_Q2_RESP}, 'yes')), 'yellow', 'green'))  # noqa: E501
             #
             # The latter produces a better expression when working with XForm tools.  # noqa: E501
-            META_NO
-            if _get_term_node_txt(ctx.BOOLEAN()) == "Y"
-            else META_YES
+            META_NO if _get_term_node_txt(ctx.BOOLEAN()) == "Y" else META_YES
         )
         meta_cee_score: str_ = _meta_cee_score_to_xls_form(
             meta_cee_score=_get_term_node_txt(ctx.CEE_SCORE()),
@@ -324,9 +320,11 @@ class ScoringLogicListener(SGHI_XLSFormListener, Listener):
             left_operand: NumberExpr = (
                 count_selected(question_expr)
                 if self._question.question_type == QT.MULTI
-                else intf(number(question_expr))
-                if self._question.question_type == QT.COUNT
-                else number(question_expr)
+                else (
+                    intf(number(question_expr))
+                    if self._question.question_type == QT.COUNT
+                    else number(question_expr)
+                )
             )
             right_operand: NumberExpr = (
                 intf(num(digits))
@@ -426,10 +424,10 @@ class ScoringLogicListener(SGHI_XLSFormListener, Listener):
         ctx: SGHI_XLSFormParser.Range_expressionContext,
     ) -> None:
         meta_lower_bound: int = int(
-            _get_term_node_txt(terminal_node=ctx.DIGITS(0)),  # type: ignore
+            _get_term_node_txt(terminal_node=ctx.DIGITS(0)),
         )
         meta_upper_bound: int = int(
-            _get_term_node_txt(terminal_node=ctx.DIGITS(1)),  # type: ignore
+            _get_term_node_txt(terminal_node=ctx.DIGITS(1)),
         )
 
         lower_bound: IntExpr = int_(meta_lower_bound)
@@ -536,9 +534,9 @@ def parse_question_scoring_logic(
     # scoring logic expression.
     if not else_expr and len(scoring_expressions) < 2:
         err_msg: str = (
-            "Error parsing the scoring logic for question {}. the 'else_expr' "
-            "parameter is needed for questions with a single scoring "
-            "rule/predicate.".format(question.id)
+            f"Error parsing the scoring logic for question {question.id}. the "
+            "'else_expr' parameter is needed for questions with a single "
+            "scoring rule/predicate."
         )
         raise AssertionError(err_msg)
 

--- a/src/sghi/mentorship_xls_forms/lib/loaders/facility_loader.py
+++ b/src/sghi/mentorship_xls_forms/lib/loaders/facility_loader.py
@@ -55,9 +55,9 @@ class FacilityJSONMetadataLoader(Loader[Iterable[Facility]]):
                 fp=self._metadata_source,
             )
         except json.JSONDecodeError as exc:
-            _err_msg: (
-                str
-            ) = f"Error loading facilities from JSON metadata: '{exc!s}'"
+            _err_msg: str = (
+                f"Error loading facilities from JSON metadata: '{exc!s}'"
+            )
             raise LoadError(message=_err_msg) from exc
         return _CONVERTER.structure(raw_metadata, Sequence[Facility])
 
@@ -77,7 +77,7 @@ class FacilityJSONMetadataLoader(Loader[Iterable[Facility]]):
                 metadata_source=open(metadata_file_path),  # noqa: SIM115
             )
         except OSError as exc:
-            _err_msg: (
-                str
-            ) = f"Error while opening metadata source file: '{exc!s}'"
+            _err_msg: str = (
+                f"Error while opening metadata source file: '{exc!s}'"
+            )
             raise LoadError(message=_err_msg) from exc

--- a/src/sghi/mentorship_xls_forms/lib/serializers/xls_form/__init__.py
+++ b/src/sghi/mentorship_xls_forms/lib/serializers/xls_form/__init__.py
@@ -297,7 +297,10 @@ def _create_question_relevance_record(question: Question) -> XLSFormRecord:
         list_name=_YesNoCL.list_name(),
         appearance="columns-pack",
         default=_YesNoCL.YES.choice_name,
-        hint=f"Select '{_YesNoCL.NO.choice_label}' to skip to the next question.",
+        hint=(
+            f"Select '{_YesNoCL.NO.choice_label}' to skip to the next "
+            "question."
+        ),
         label=label,
         name=_get_question_relevance_record_id(question),
         relevant="yes" if question.na_option else "no",

--- a/src/sghi/mentorship_xls_forms/lib/writers/xls_form.py
+++ b/src/sghi/mentorship_xls_forms/lib/writers/xls_form.py
@@ -1,10 +1,9 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, BinaryIO, Final, Self, TypeVar, cast
+from typing import Any, BinaryIO, Final, Self, cast, override
 
 import cattrs
 import pyexcel
-from attrs import AttrsInstance, define, field, fields
-from typing_extensions import override
+from attrs import define, field, fields
 
 from sghi.disposable import not_disposed
 from sghi.mentorship_xls_forms.core import Writer
@@ -15,14 +14,6 @@ from sghi.mentorship_xls_forms.lib.xls_forms import (
     XLSFormSettings,
 )
 from sghi.utils import ensure_not_none
-
-# =============================================================================
-# TYPES
-# =============================================================================
-
-
-_AT = TypeVar("_AT", bound=AttrsInstance)
-
 
 # =============================================================================
 # CONSTANT
@@ -106,14 +97,18 @@ class XLSFormWriter(Writer[XLSForm]):
         )
 
     @staticmethod
-    def _objects_to_xls(
+    def _objects_to_xls[
+        _AT
+    ](
         object_klass: type[_AT],
         objects: Iterable[_AT],
-    ) -> Sequence[Sequence[Any]]:
+    ) -> Sequence[
+        Sequence[Any]
+    ]:
         ensure_not_none(object_klass, "'object_klass' MUST not be None.")
         ensure_not_none(objects, "'objects' MUST not be None.")
-        xls_entries = [
-            _CONVERTER.unstructure(an_object) for an_object in objects
+        xls_entries: list[Any] = [
+            list(_CONVERTER.unstructure(an_object)) for an_object in objects
         ]
         header_row: Sequence[str] = [
             attribute.name for attribute in fields(object_klass)

--- a/src/sghi/mentorship_xls_forms/lib/xls_forms/core.py
+++ b/src/sghi/mentorship_xls_forms/lib/xls_forms/core.py
@@ -61,7 +61,7 @@ class XLSFormChoice:
 
 @define
 class XLSFormRecord:
-    type: XLSFormElementType = field()  # noqa: A003
+    type: XLSFormElementType = field()
     appearance: str | None = field(default=None, kw_only=True, repr=False)
     calculation: str | None = field(default=None, kw_only=True, repr=False)
     choice_filter: str | None = field(default=None, kw_only=True, repr=False)

--- a/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/base.py
+++ b/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/base.py
@@ -41,13 +41,13 @@ BLANK_RESULT: Final[XPathExpr] = XPathExpr("")
 
 
 @overload
-def python_number_to_xls_form_number(number: int | IntExpr) -> IntExpr:
-    ...
+def python_number_to_xls_form_number(number: int | IntExpr) -> IntExpr: ...
 
 
 @overload
-def python_number_to_xls_form_number(number: float | NumberExpr) -> NumberExpr:
-    ...
+def python_number_to_xls_form_number(
+    number: float | NumberExpr,
+) -> NumberExpr: ...
 
 
 def python_number_to_xls_form_number(
@@ -241,12 +241,10 @@ class NumberExpr(Expr, SupportsIndex, SupportsRound, metaclass=ABCMeta):
         return pow_(self, python_number_to_xls_form_number(power))
 
     @overload
-    def __round__(self, places: int = 2) -> NumberExpr:
-        ...
+    def __round__(self, places: int = 2) -> NumberExpr: ...
 
     @overload
-    def __round__(self, places: IntExpr | None = None) -> NumberExpr:
-        ...
+    def __round__(self, places: IntExpr | None = None) -> NumberExpr: ...
 
     def __round__(self, places: int | IntExpr | None = None) -> NumberExpr:
         from .functions import round_
@@ -386,7 +384,7 @@ class Variable(Expr):
         )
 
     def __eval__(self) -> XPathExpr:
-        return XPathExpr("${%s}" % self.question_name)
+        return XPathExpr(f"${self.question_name}")
 
 
 brkt = Brackets

--- a/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/literals.py
+++ b/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/literals.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar
-
 from attrs import field, frozen
 
 from .base import BoolExpr, Expr, IntExpr, NumberExpr, TextExpr, XPathExpr
@@ -13,8 +11,6 @@ from .base import BoolExpr, Expr, IntExpr, NumberExpr, TextExpr, XPathExpr
 
 _Number = int | float
 
-_T = TypeVar("_T")
-
 
 # =============================================================================
 # LITERALS
@@ -22,7 +18,7 @@ _T = TypeVar("_T")
 
 
 @frozen
-class LiteralValue(Expr, Generic[_T]):
+class LiteralValue[_T](Expr):
     value: _T = field()
 
     def __eval__(self) -> XPathExpr:
@@ -36,13 +32,11 @@ class Boolean(BoolExpr, LiteralValue[bool]):
 
 
 @frozen(eq=False)
-class Int(IntExpr, LiteralValue[int]):
-    ...
+class Int(IntExpr, LiteralValue[int]): ...
 
 
 @frozen(eq=False)
-class Number(NumberExpr, LiteralValue[_Number]):
-    ...
+class Number(NumberExpr, LiteralValue[_Number]): ...
 
 
 @frozen(eq=False)

--- a/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/operators.py
+++ b/src/sghi/mentorship_xls_forms/lib/xls_forms/expressions/operators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta
-from typing import Generic, Self, TypeVar
+from typing import Self
 
 from attrs import field, frozen
 
@@ -15,10 +15,6 @@ from .base import BoolExpr, Expr, NumberExpr, TextExpr, XPathExpr, eval
 
 
 _AlphaNumeric = NumberExpr | TextExpr
-
-_E1 = TypeVar("_E1", bound=Expr)
-
-_E2 = TypeVar("_E2", bound=Expr)
 
 
 # =============================================================================
@@ -42,12 +38,12 @@ class Operator(Expr, metaclass=ABCMeta):
 
 
 @frozen
-class BiOperator(Operator, Generic[_E1, _E2]):
+class BiOperator[_LHT: Expr, _RHT: Expr](Operator):
     """An XLSForm binary operator."""
 
     operator: str = field()
-    left_operand: _E1 = field()
-    right_operand: _E2 = field()
+    left_operand: _LHT = field()
+    right_operand: _RHT = field()
 
     def __attrs_post_init__(self) -> None:
         ensure_not_none(self.operator, "'operator' MUST not be None.")
@@ -59,7 +55,7 @@ class BiOperator(Operator, Generic[_E1, _E2]):
 
     def __eval__(self) -> XPathExpr:
         return XPathExpr(
-            "{}{}{}".format(
+            "{}{}{}".format(  # noqa: UP032
                 eval(self.left_operand),
                 self.operator,
                 eval(self.right_operand),

--- a/src/sghi/mentorship_xls_forms/use_cases/__init__.py
+++ b/src/sghi/mentorship_xls_forms/use_cases/__init__.py
@@ -22,19 +22,19 @@ from sghi.utils import ensure_not_none, ensure_not_none_nor_empty
 # =============================================================================
 
 
-_CLF = Callable[[str], Loader[Iterable[Checklist]]]
+type _CLF = Callable[[str], Loader[Iterable[Checklist]]]
 """Checklist Loader Factory."""
 
-_CSF = Callable[[], Serializer[Checklist, XLSForm]]
+type _CSF = Callable[[], Serializer[Checklist, XLSForm]]
 """Checklist Serializer Factory."""
 
-_CWF = Callable[[str], Writer[XLSForm]]
+type _CWF = Callable[[str], Writer[XLSForm]]
 """Checklist Writer Factory."""
 
-_FLF = Callable[[str], Loader[Iterable[Facility]]]
+type _FLF = Callable[[str], Loader[Iterable[Facility]]]
 """Facility Loader Factory."""
 
-_FSF = Callable[[], Serializer[Iterable[Facility], XLSFormItem]]
+type _FSF = Callable[[], Serializer[Iterable[Facility], XLSFormItem]]
 """Facility Serializer Factory."""
 
 


### PR DESCRIPTION
Change the supported Python version from py310 to py312.

Upgrade all dependencies except [openpyxl](https://openpyxl.readthedocs.io/en/stable/). See [this issue](https://github.com/pyexcel/pyexcel-xlsx/issues/52) for details.